### PR TITLE
Add `--help` argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,10 @@ int main(int argc, char** argv, char** envp) {
             } else if (arg == "--no-fancy") {
                 g_pHyprpicker->m_bFancyOutput = false;
             } else {
-                Debug::log(NONE, "Unrecognized option %s", arg.c_str());
+                std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n" <<
+                    " --format [fmt]  | Specifies the output format (hex, rgb)\n" <<
+                    " --no-fancy      | Disables the \"fancy\" (aka. colored) outputting\n" <<
+                    " --help          | Show this help message\n";
                 exit(1);
             }
         } else if (currentlyParsing == 1) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It adds the argument `--help` in almost the exact same style as Hyprland.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
It removes `Debug::log(NONE, "Unrecognized option %s", arg.c_str());`. However, that matches the style of Hyprland.

#### Is it ready for merging, or does it need work?
It is ready for merging.
