### PR TITLE
Support HSL, HSV, CMYK, short options, minor I/O fix, and add a manual page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ PKGS = wlroots wayland-server
 CFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
 LDLIBS += $(foreach p,$(PKGS),$(shell pkg-config --libs $(p)))
 
+default: all
+
 wlr-layer-shell-unstable-v1-protocol.h:
 	$(WAYLAND_SCANNER) client-header \
 		protocols/wlr-layer-shell-unstable-v1.xml $@
@@ -58,3 +60,8 @@ all:
 	make clear
 	make protocols
 	make release
+
+install:
+	mkdir -p ${DESTDIR}${PREFIX}/bin ${DESTDIR}${PREFIX}/share/man/man1
+	cp doc/hyprpicker.1 ${DESTDIR}${PREFIX}/share/man/man1
+	cp build/hyprpicker ${DESTDIR}${PREFIX}/bin

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Launch it. Click. That's it.
 
 ## Options
 
-`--format [fmt]` to specify the output format (`hex`, `rgb`)
+`-f | --format=[fmt]` specifies the output format (`hex`, `rgb`)
 
-`--no-fancy` disables the "fancy" (aka. colored) outputting
+`-n | --no-fancy` disables the "fancy" (aka. colored) outputting
+
+`-h | --help` prints a help message
 
 # Building
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Launch it. Click. That's it.
 
 ## Options
 
-`-f | --format=[fmt]` specifies the output format (`hex`, `rgb`)
+`-f | --format=[fmt]` specifies the output format (`cmyk`, `hex`, `rgb`, `hsl`, `hsv`)
 
 `-n | --no-fancy` disables the "fancy" (aka. colored) outputting
 

--- a/doc/hyprpicker.1
+++ b/doc/hyprpicker.1
@@ -1,0 +1,80 @@
+.Dd $Mdocdate: November 14 2022 $
+.Dt HYPRPICKER 1
+.Os Linux
+.Sh NAME
+.Nm hyprpicker
+.Nd wlroots-compatible wayland color picker
+.Sh SYNOPSIS
+.Nm
+.Op Fl nh
+.Op Fl f Ar fmt
+.Sh DESCRIPTION
+The
+.Nm
+utility is a color-picker with support for various output formats.
+When
+.Nm
+is invoked the cursor is transformed into a magnifying lens, and clicking on any
+pixel of the screen will print out that pixels color to the standard output.
+The default output format is hexadecimal, but that can be configured with the
+.Fl f
+option.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl f Ns , Fl \-format Ns = Ns Ar fmt
+Select the format to output the selected pixels color in.
+The available options are:
+.Pp
+.Bl -hang -compact
+.It Ar hex
+.Pq Dq #RRGGBB
+.It Ar rgb
+.Pq Dq R G B
+.It Ar hsl
+.Pq Dq H S% L%
+.It Ar hsv
+.Pq Dq H S% V%
+.El
+.Pp
+The default format is
+.Ar hex .
+.It Fl n Ns , Fl \-no\-fancy
+Disable colored output.
+Default behavior is to color the output in the same color as the selected pixel.
+.It Fl h Ns , Fl \-help
+Display a help message and exit successfully from the program.
+.El
+.Sh ENVIRONMENT
+.Bl -tag -width NO_COLOR
+.It Ev NO_COLOR
+If set, disables colored output.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Get a pixels color:
+.Pp
+.Dl $ hyprpicker
+.Pp
+Get a pixels color in HSL, wrapped in a CSS
+.Fn hsl
+function:
+.Pp
+.Dl $ hyprpicker -f hsl | sed 's/^/rgb(/; s/$/)/; y/ /,/'
+.Sh SEE ALSO
+.Xr hyprctl 1 ,
+.Xr hyprland 1 ,
+.Xr sed 1
+.Pp
+.Lk https://github.com/hyprwm/hyprpicker "The Hyprpicker Sources"
+.Sh AUTHORS
+.An -nosplit
+The
+.Nm
+utility was originally written by
+.An Vaxerski Aq Lk https://github.com/vaxerski
+and the manual page by
+.An Thomas Voss Aq Mt mail@thomasvoss.com .
+.Sh BUGS
+.Lk https://github.com/hyprwm/hyprpicker/issues "The Hyprpicker Bug Tracker"

--- a/doc/hyprpicker.1
+++ b/doc/hyprpicker.1
@@ -24,9 +24,14 @@ The options are as follows:
 .Bl -tag -width Ds
 .It Fl f Ns , Fl \-format Ns = Ns Ar fmt
 Select the format to output the selected pixels color in.
+The argument
+.Ar fmt
+is case-insensitive.
 The available options are:
 .Pp
 .Bl -hang -compact
+.It Ar cmyk
+.Pq Dq C% M% Y% K%
 .It Ar hex
 .Pq Dq #RRGGBB
 .It Ar rgb

--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -181,7 +181,7 @@ void Events::handlePointerButton(void *data, struct wl_pointer *wl_pointer, uint
                 h = 60 * (0 + (g - b) / c);
             else if (v == g)
                 h = 60 * (2 + (b - r) / c);
-            else if (v == b)
+            else /* v == b */
                 h = 60 * (4 + (r - g) / c);
 
             float l_or_v;

--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -143,7 +143,7 @@ void Events::handlePointerButton(void *data, struct wl_pointer *wl_pointer, uint
             };
 
             if (g_pHyprpicker->m_bFancyOutput)
-                Debug::log(NONE, "\033[38;2;%i;%i;%im #%s%s%s\033[0m", COL.r, COL.g, COL.b, toHex(COL.r).c_str(), toHex(COL.g).c_str(), toHex(COL.b).c_str());
+                Debug::log(NONE, "\033[38;2;%i;%i;%im#%s%s%s\033[0m", COL.r, COL.g, COL.b, toHex(COL.r).c_str(), toHex(COL.g).c_str(), toHex(COL.b).c_str());
             else
                 Debug::log(NONE, "#%s%s%s", toHex(COL.r).c_str(), toHex(COL.g).c_str(), toHex(COL.b).c_str());
 
@@ -152,7 +152,7 @@ void Events::handlePointerButton(void *data, struct wl_pointer *wl_pointer, uint
         case OUTPUT_RGB:
         {
             if (g_pHyprpicker->m_bFancyOutput)
-                Debug::log(NONE, "\033[38;2;%i;%i;%im %i %i %i\033[0m", COL.r, COL.g, COL.b, COL.r, COL.g, COL.b);
+                Debug::log(NONE, "\033[38;2;%i;%i;%im%i %i %i\033[0m", COL.r, COL.g, COL.b, COL.r, COL.g, COL.b);
             else
                 Debug::log(NONE, "%i %i %i", COL.r, COL.g, COL.b);
             break;

--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -157,6 +157,41 @@ void Events::handlePointerButton(void *data, struct wl_pointer *wl_pointer, uint
                 Debug::log(NONE, "%i %i %i", COL.r, COL.g, COL.b);
             break;
         }
+        case OUTPUT_HSL:
+        {
+            // https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB
+
+            float h, s, l;
+            float r = COL.r / 255.0f,
+                  g = COL.g / 255.0f,
+                  b = COL.b / 255.0f;
+            float max = (r > g && r > b) ? r : (g > b) ? g : b,
+                  min = (r < g && r < b) ? r : (g < b) ? g : b;
+            float c = max - min;
+
+            l = (max + min) / 2;
+            if (c == 0)
+                h = s = 0;
+            else {
+                s = (max - l) / std::min(l, 1 - l);
+                if (max == r)
+                    h = 60 * (0 + (g - b) / c);
+                else if (max == g)
+                    h = 60 * (2 + (b - r) / c);
+                else if (max == b)
+                    h = 60 * (4 + (r - g) / c);
+            }
+
+            h = std::round(h);
+            s = std::round(s * 100);
+            l = std::round(l * 100);
+
+            if (g_pHyprpicker->m_bFancyOutput)
+                Debug::log(NONE, "\033[38;2;%i;%i;%im%g %g%% %g%%\033[0m", COL.r, COL.g, COL.b, h, s, l);
+            else
+                Debug::log(NONE, "%g %g%% %g%%", h, s, l);
+            break;
+        }
     }
 
     g_pHyprpicker->finish();

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -7,7 +7,8 @@
 enum eOutputMode {
     OUTPUT_HEX = 0,
     OUTPUT_RGB,
-    OUTPUT_HSL
+    OUTPUT_HSL,
+    OUTPUT_HSV
 };
 
 class CHyprpicker {

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -5,7 +5,8 @@
 #include "helpers/PoolBuffer.hpp"
 
 enum eOutputMode {
-    OUTPUT_HEX = 0,
+    OUTPUT_CMYK = 0,
+    OUTPUT_HEX,
     OUTPUT_RGB,
     OUTPUT_HSL,
     OUTPUT_HSV

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -6,7 +6,8 @@
 
 enum eOutputMode {
     OUTPUT_HEX = 0,
-    OUTPUT_RGB
+    OUTPUT_RGB,
+    OUTPUT_HSL
 };
 
 class CHyprpicker {

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -33,6 +33,7 @@ extern "C" {
 #include <cairo.h>
 #include <cairo/cairo.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,39 +2,50 @@
 #include "hyprpicker.hpp"
 
 
+static void help(void) {
+    std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n" <<
+        " -f | --format=fmt  | Specifies the output format (hex, rgb)\n" <<
+        " -n | --no-fancy    | Disables the \"fancy\" (aka. colored) outputting\n" <<
+        " -h | --help        | Show this help message\n";
+}
+
 int main(int argc, char** argv, char** envp) {
     g_pHyprpicker = std::make_unique<CHyprpicker>();
 
-    // parse args
-    // 1 - format
-    int currentlyParsing = 0;
-    for (int i = 1; i < argc; i++) {
-        std::string arg = argv[i];
+    while (true) {
+        int option_index = 0;
+        static struct option long_options[] = {
+            {"format",   required_argument, NULL, 'f'},
+            {"help",     no_argument,       NULL, 'h'},
+            {"no-fancy", no_argument,       NULL, 'n'},
+            {NULL,       0,                 NULL,  0 }
+        };
 
-        if (currentlyParsing == 0) {
-            if (arg == "--format") {
-                currentlyParsing = 1;
-                continue;
-            } else if (arg == "--no-fancy") {
+        int c = getopt_long(argc, argv, ":f:hn", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'f':
+                if (strcmp(optarg, "hex") == 0)
+                    g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HEX;
+                else if (strcmp(optarg, "rgb") == 0)
+                    g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_RGB;
+                else {
+                    Debug::log(NONE, "Unrecognized format %s", optarg);
+                    exit(1);
+                }
+                break;
+            case 'h':
+                help();
+                exit(0);
+            case 'n':
                 g_pHyprpicker->m_bFancyOutput = false;
-            } else {
-                std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n" <<
-                    " --format [fmt]  | Specifies the output format (hex, rgb)\n" <<
-                    " --no-fancy      | Disables the \"fancy\" (aka. colored) outputting\n" <<
-                    " --help          | Show this help message\n";
+                break;
+            default:
+                help();
                 exit(1);
             }
-        } else if (currentlyParsing == 1) {
-            if (arg == "hex") g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HEX;
-            else if (arg == "rgb") g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_RGB;
-            else {
-                Debug::log(NONE, "Unrecognized format %s", arg.c_str());
-                exit(1);
-            }
-
-            currentlyParsing = 0;
-            continue;
-        }
     }
 
     if (!isatty(fileno(stdout)) || getenv("NO_COLOR"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 
 static void help(void) {
     std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n" <<
-        " -f | --format=fmt  | Specifies the output format (hex, rgb, hsl)\n" <<
+        " -f | --format=fmt  | Specifies the output format (hex, rgb, hsl, hsv)\n" <<
         " -n | --no-fancy    | Disables the \"fancy\" (aka. colored) outputting\n" <<
         " -h | --help        | Show this help message\n";
 }
@@ -33,6 +33,8 @@ int main(int argc, char** argv, char** envp) {
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_RGB;
                 else if (strcmp(optarg, "hsl") == 0)
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HSL;
+                else if (strcmp(optarg, "hsv") == 0)
+                    g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HSV;
                 else {
                     Debug::log(NONE, "Unrecognized format %s", optarg);
                     exit(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 
 static void help(void) {
     std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n" <<
-        " -f | --format=fmt  | Specifies the output format (hex, rgb)\n" <<
+        " -f | --format=fmt  | Specifies the output format (hex, rgb, hsl)\n" <<
         " -n | --no-fancy    | Disables the \"fancy\" (aka. colored) outputting\n" <<
         " -h | --help        | Show this help message\n";
 }
@@ -31,6 +31,8 @@ int main(int argc, char** argv, char** envp) {
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HEX;
                 else if (strcmp(optarg, "rgb") == 0)
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_RGB;
+                else if (strcmp(optarg, "hsl") == 0)
+                    g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HSL;
                 else {
                     Debug::log(NONE, "Unrecognized format %s", optarg);
                     exit(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,10 @@
+#include <strings.h>
 #include <iostream>
 #include "hyprpicker.hpp"
 
-
 static void help(void) {
     std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n" <<
-        " -f | --format=fmt  | Specifies the output format (hex, rgb, hsl, hsv)\n" <<
+        " -f | --format=fmt  | Specifies the output format (cmyk, hex, rgb, hsl, hsv)\n" <<
         " -n | --no-fancy    | Disables the \"fancy\" (aka. colored) outputting\n" <<
         " -h | --help        | Show this help message\n";
 }
@@ -27,13 +27,15 @@ int main(int argc, char** argv, char** envp) {
 
         switch (c) {
             case 'f':
-                if (strcmp(optarg, "hex") == 0)
+                if (strcasecmp(optarg, "cmyk") == 0)
+                    g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_CMYK;
+                else if (strcasecmp(optarg, "hex") == 0)
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HEX;
-                else if (strcmp(optarg, "rgb") == 0)
+                else if (strcasecmp(optarg, "rgb") == 0)
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_RGB;
-                else if (strcmp(optarg, "hsl") == 0)
+                else if (strcasecmp(optarg, "hsl") == 0)
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HSL;
-                else if (strcmp(optarg, "hsv") == 0)
+                else if (strcasecmp(optarg, "hsv") == 0)
                     g_pHyprpicker->m_bSelectedOutputMode = OUTPUT_HSV;
                 else {
                     Debug::log(NONE, "Unrecognized format %s", optarg);


### PR DESCRIPTION
- use getopt\_long(3) and support short options
- remove initial space when m\_bFancyOutput is true
- add the HSL format
- add the HSV format
- add the CMYK format
- add a manual page
- make `all` the default `make(1)` target, and add an `install` rule
