### PR TITLE
Add keyboard listener and listen to escape to quit hyprpicker

### DIFF
--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -78,6 +78,10 @@ void Events::handleCapabilities(void *data, wl_seat *wl_seat, uint32_t capabilit
         Debug::log(CRIT, "Hyprpicker cannot work without a pointer!");
         g_pHyprpicker->finish(1);
     }
+
+    if (capabilities & WL_SEAT_CAPABILITY_KEYBOARD) {
+        wl_keyboard_add_listener(wl_seat_get_keyboard(wl_seat), &keyboardListener, wl_seat);
+    }
 }
 
 void Events::handlePointerEnter(void *data, struct wl_pointer *wl_pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t surface_x, wl_fixed_t surface_y) {
@@ -255,6 +259,33 @@ void Events::handlePointerButton(void *data, struct wl_pointer *wl_pointer, uint
     if (!g_pHyprpicker->m_bAutoCopy)
         g_pHyprpicker->finish();
 }
+
+void Events::handleKeyboardKeymap(void* data, wl_keyboard* wl_keyboard, uint format, int fd, uint size)
+{
+
+}
+
+void Events::handleKeyboardKey(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    if(key == 1) // escape
+        g_pHyprpicker->finish();
+}
+
+void Events::handleKeyboardEnter(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface, wl_array* keys)
+{
+
+}
+
+void Events::handleKeyboardLeave(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface)
+{
+
+}
+
+void Events::handleKeyboardModifiers(void* data, wl_keyboard* wl_keyboard, uint serial, uint mods_depressed, uint mods_latched, uint mods_locked, uint group)
+{
+
+}
+
 
 void Events::handleFrameDone(void *data, struct wl_callback *callback, uint32_t time) {
     CLayerSurface* pLS = (CLayerSurface*)data;

--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -260,29 +260,24 @@ void Events::handlePointerButton(void *data, struct wl_pointer *wl_pointer, uint
         g_pHyprpicker->finish();
 }
 
-void Events::handleKeyboardKeymap(void* data, wl_keyboard* wl_keyboard, uint format, int fd, uint size)
-{
+void Events::handleKeyboardKeymap(void* data, wl_keyboard* wl_keyboard, uint format, int fd, uint size) {
 
 }
 
-void Events::handleKeyboardKey(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
-{
-    if(key == 1) // escape
+void Events::handleKeyboardKey(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
+    if (key == 1) // escape
         g_pHyprpicker->finish();
 }
 
-void Events::handleKeyboardEnter(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface, wl_array* keys)
-{
+void Events::handleKeyboardEnter(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface, wl_array* keys) {
 
 }
 
-void Events::handleKeyboardLeave(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface)
-{
+void Events::handleKeyboardLeave(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface) {
 
 }
 
-void Events::handleKeyboardModifiers(void* data, wl_keyboard* wl_keyboard, uint serial, uint mods_depressed, uint mods_latched, uint mods_locked, uint group)
-{
+void Events::handleKeyboardModifiers(void* data, wl_keyboard* wl_keyboard, uint serial, uint mods_depressed, uint mods_latched, uint mods_locked, uint group) {
 
 }
 

--- a/src/events/Events.hpp
+++ b/src/events/Events.hpp
@@ -33,6 +33,16 @@ namespace Events {
 
     void handlePointerLeave(void *data, struct wl_pointer *wl_pointer, uint32_t serial, struct wl_surface *surface);
 
+    void handleKeyboardKeymap(void* data, wl_keyboard* wl_keyboard, uint format, int fd, uint size);
+
+    void handleKeyboardKey(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    
+    void handleKeyboardEnter(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface, wl_array* keys);
+
+    void handleKeyboardLeave(void* data, wl_keyboard* wl_keyboard, uint serial, wl_surface* surface);
+
+    void handleKeyboardModifiers(void* data, wl_keyboard* wl_keyboard, uint serial, uint mods_depressed, uint mods_latched, uint mods_locked, uint group);
+
     void handleFrameDone(void *data, struct wl_callback *callback, uint32_t time);
 
     void handleBufferRelease(void *data, struct wl_buffer *wl_buffer);
@@ -54,6 +64,8 @@ namespace Events {
     inline const wl_seat_listener seatListener = { .capabilities = handleCapabilities };
 
     inline const wl_pointer_listener pointerListener = { .enter = handlePointerEnter, .leave = handlePointerLeave, .motion = handlePointerMotion, .button = handlePointerButton, .axis = handlePointerAxis };
+
+    inline const wl_keyboard_listener keyboardListener = { .keymap = handleKeyboardKeymap, .enter = handleKeyboardEnter,.leave = handleKeyboardLeave, .key = handleKeyboardKey, .modifiers = handleKeyboardModifiers };
 
     inline const wl_callback_listener frameListener = { .done = handleFrameDone };
 


### PR DESCRIPTION
Hi! I've never written wayland code, but I think I've got this working okay. You can now press escape to exit hyprpicker without copying a color.
My only doubt is for line 270, how can I check whether the escape keycode was pressed? I found it is 1 on my system through debugging, but I'm unsure whether this will be consistent on other machines.