### PR TITLE
Use xkbcommon for keyboard event handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-m
 find_package(Threads REQUIRED)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-client wayland-protocols cairo pango pangocairo libjpeg)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-client wayland-protocols xkbcommon cairo pango pangocairo libjpeg)
 
 file(GLOB_RECURSE SRCFILES "src/*.cpp")
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,6 +11,7 @@
   libselinux,
   libsepol,
   libthai,
+  libxkbcommon,
   pango,
   pcre,
   utillinux,
@@ -50,6 +51,7 @@ stdenv.mkDerivation {
     wayland-scanner
     wlroots
     libXdmcp
+    libxkbcommon
     utillinux
   ];
 

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -8,6 +8,10 @@ void sigHandler(int sig) {
 }
 
 void CHyprpicker::init() {
+    m_pXKBContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!m_pXKBContext)
+        Debug::log(ERR, "Failed to create xkb context");
+
     m_pWLDisplay = wl_display_connect(nullptr);
 
     if (!m_pWLDisplay) {

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -26,6 +26,10 @@ class CHyprpicker {
     zwlr_layer_shell_v1*                        m_pLayerShell;
     zwlr_screencopy_manager_v1*                 m_pSCMgr;
 
+    xkb_context*                                m_pXKBContext = nullptr;
+    xkb_keymap*                                 m_pXKBKeymap  = nullptr;
+    xkb_state*                                  m_pXKBState   = nullptr;
+
     eOutputMode                                 m_bSelectedOutputMode = OUTPUT_HEX;
 
     bool                                        m_bFancyOutput = true;

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -40,6 +40,7 @@ extern "C" {
 #include <sys/mman.h>
 #include <unistd.h>
 #include <wayland-client.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include <algorithm>
 #include <filesystem>


### PR DESCRIPTION
Fixes #41.

This is my first time writing C++ in a long time, so I might have put some things in the wrong place.

Errors in initialising xkb are logged, but not treated as fatal. If we can't initialise xkb, we just don't handle keypresses at all.