### PR TITLE
Add install targets and manpage files for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4)
-project(hyprpicker 
+project(hyprpicker
     DESCRIPTION "A blazing fast wayland wallpaper utility"
 )
 
@@ -76,3 +76,12 @@ IF(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg -no-pie -fno-builtin")
     SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg -no-pie -fno-builtin")
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
+
+include(GNUInstallDirs)
+install(TARGETS hyprpicker
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/hyprpicker.1
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+)


### PR DESCRIPTION
In accomodation with the install steps in Makefile.

https://github.com/hyprwm/hyprpicker/blob/b6130e3901ed5c6d423f168705929e555608d870/Makefile#L64-L67