### PR TITLE
fix: nixos build, missing ligblvnd

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,6 +7,7 @@
   cairo,
   fribidi,
   libdatrie,
+  libGL,
   libjpeg,
   libselinux,
   libsepol,
@@ -40,6 +41,7 @@ stdenv.mkDerivation {
     cairo
     fribidi
     libdatrie
+    libGL
     libjpeg
     libselinux
     libsepol


### PR DESCRIPTION
Fix NixOS build, should close #52

Tested it locally on x86_64-linux.