### PR TITLE
Add error message for when compositor does not support required protcols

### DIFF
--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -28,6 +28,12 @@ void CHyprpicker::init() {
 
     wl_display_roundtrip(m_pWLDisplay);
 
+    if (!m_pSCMgr) {
+        Debug::log(CRIT, "Compositor doesn't support wlr_screencopy_unstable_v1!");
+        exit(1);
+        return;
+    }
+
     for (auto& m : m_vMonitors) {
         m_vLayerSurfaces.emplace_back(std::make_unique<CLayerSurface>(m.get()));
 


### PR DESCRIPTION
Adds a check to `init()` to verify the `zwlr_screencopy_manager` exists before using it to avoid a vague 'Segmentation Fault' (like seen in #51) when used on a system that does not implement the `wlr_screencopy_unstable_v1` protocol.

As I'm one of the people who experienced the Seg Fault on KDE, I set up Hyprland on my laptop to make sure this didn't break functionality on the intended platform.