### PR TITLE
cmake: remove unneeded dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,6 @@ include(CPack)
 target_link_libraries(hyprpicker PkgConfig::deps)
 
 target_link_libraries(hyprpicker
-        OpenGL
-        GLESv2
         pthread
         ${CMAKE_THREAD_LIBS_INIT}
         wayland-cursor


### PR DESCRIPTION
This PR proposes to remove both OpenGL and GLESv2 dependencies from the build as it seems they are not needed.

Fixes #80 