### PR TITLE
remove unneeded GLES headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Launch it. Click. That's it.
 Install build dependencies (Debian):
 
 ```sh
-apt install --no-install-recommends -y cmake g++ make pkg-config libpango1.0-dev libjpeg-dev libwayland-dev wayland-protocols libxkbcommon-dev libgles2-mesa-dev
+apt install --no-install-recommends -y cmake g++ make pkg-config libpango1.0-dev libjpeg-dev libwayland-dev wayland-protocols libxkbcommon-dev
 ```
 
 Building is done via CMake:

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -28,8 +28,6 @@ extern "C" {
 #undef namespace
 #undef static
 
-#include <GLES3/gl32.h>
-#include <GLES3/gl3ext.h>
 #include <assert.h>
 #include <cairo.h>
 #include <cairo/cairo.h>


### PR DESCRIPTION
I wasn't careful enough while writing #81 and I missed these two headers.

Since GLES was also removed, they are not needed anymore.

Also update, README.md while at it.