### PR TITLE
deps: utillinux has been renamed to util-linux

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,7 +17,7 @@
   pango,
   pcre,
   pcre2,
-  utillinux,
+  util-linux,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
     pango
     pcre
     pcre2
-    utillinux
+    util-linux
     wayland
     wayland-protocols
     wayland-scanner


### PR DESCRIPTION
`utillinux` now throws an error
see https://github.com/NixOS/nixpkgs/blob/73d8d52149461e2b70a1ad2b90fd7cbb0e16c267/pkgs/top-level/aliases.nix#L1676