### PR TITLE
feat: adds hexcode below the cursor 

### DIFF
--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -388,6 +388,7 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
         // |           |
         // | --------- |
         //
+        // (#hex code here)
 
         cairo_restore(PCAIRO);
         if (!m_bNoZoom) {
@@ -424,6 +425,22 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             cairo_clip(PCAIRO);
             cairo_paint(PCAIRO);
 
+            const auto THECOLOR = getColorFromPixel(pSurface, CLICKPOS);
+            printf("thecolor has been gotten and it is %d %d %d\n", THECOLOR.r, THECOLOR.g, THECOLOR.b);
+
+            char hexBuffer[8];
+            sprintf(hexBuffer, "#%02x%02x%02x", THECOLOR.r, THECOLOR.g, THECOLOR.b);
+
+            cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
+            printf("hallo\n");
+            cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+            cairo_set_font_size(PCAIRO, 18);
+            cairo_move_to(PCAIRO, CLICKPOS.x, CLICKPOS.y + 40);
+            printf("pos is %f %f\n", CLICKPOS.x, CLICKPOS.y);
+            printf("Rendering hex code at position: (%f, %f)\n", CLICKPOS.x, CLICKPOS.y + 40);
+
+            printf("hexbuffer contains %s\n", hexBuffer);
+            cairo_show_text(PCAIRO, hexBuffer);
             cairo_surface_flush(PBUFFER->surface);
 
             cairo_restore(PCAIRO);
@@ -447,7 +464,6 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
         cairo_paint(PCAIRO);
 
         cairo_surface_flush(PBUFFER->surface);
-
         cairo_pattern_destroy(PATTERNPRE);
     }
 

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -425,9 +425,8 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             cairo_clip(PCAIRO);
             cairo_paint(PCAIRO);
 
-            const auto currentColor = getColorFromPixel(pSurface, CLICKPOS);
-            char       hexBuffer[8];
-            sprintf(hexBuffer, "#%02X%02X%02X", currentColor.r, currentColor.g, currentColor.b);
+            const auto  currentColor = getColorFromPixel(pSurface, CLICKPOS);
+            std::string hexBuffer    = std::format("#{:02X}{:02X}{:02X}", currentColor.r, currentColor.g, currentColor.b);
 
             cairo_set_source_rgba(PCAIRO, 0.0, 0.0, 0.0, 0.5);
 
@@ -473,7 +472,7 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
                 cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
             }
 
-            cairo_show_text(PCAIRO, hexBuffer);
+            cairo_show_text(PCAIRO, hexBuffer.c_str());
 
             cairo_surface_flush(PBUFFER->surface);
             cairo_restore(PCAIRO);

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -462,15 +462,14 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
                 double padding = 5.0;
                 double textX   = x + padding;
 
-                if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100))
                     cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
-                } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
+                else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50))
                     cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
-                } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100))
                     cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
-                } else {
+                else
                     cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
-                }
 
                 cairo_show_text(PCAIRO, hexBuffer.c_str());
 

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -424,7 +424,8 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             cairo_arc(PCAIRO, CLICKPOS.x, CLICKPOS.y, 100 / SCALEBUFS.x, 0, 2 * M_PI);
             cairo_clip(PCAIRO);
             cairo_paint(PCAIRO);
-            if (!m_bDisableLive) {
+
+            if (!m_bDisableHexPreview) {
                 const auto  currentColor = getColorFromPixel(pSurface, CLICKPOS);
                 std::string hexBuffer    = std::format("#{:02X}{:02X}{:02X}", currentColor.r, currentColor.g, currentColor.b);
 

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -429,6 +429,10 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             char       hexBuffer[8];
             sprintf(hexBuffer, "#%02x%02x%02x", currentColor.r, currentColor.g, currentColor.b);
 
+            cairo_set_source_rgba(PCAIRO, 0.0, 0.0, 0.0, 0.5);
+            cairo_rectangle(PCAIRO, CLICKPOS.x, CLICKPOS.y + 20, 80, 30);
+            cairo_fill(PCAIRO);
+
             cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
             cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
             cairo_set_font_size(PCAIRO, 18);

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -388,7 +388,7 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
         // |           |
         // | --------- |
         //
-        // (#hex code here)
+        // (hex code here)
 
         cairo_restore(PCAIRO);
         if (!m_bNoZoom) {
@@ -430,12 +430,26 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             sprintf(hexBuffer, "#%02x%02x%02x", currentColor.r, currentColor.g, currentColor.b);
 
             cairo_set_source_rgba(PCAIRO, 0.0, 0.0, 0.0, 0.5);
-            cairo_rectangle(PCAIRO, CLICKPOS.x, CLICKPOS.y + 20, 80, 30);
+
+            double x      = CLICKPOS.x;
+            double y      = CLICKPOS.y + 19;
+            double width  = 89;
+            double height = 30;
+            double radius = 6;
+
+            cairo_move_to(PCAIRO, x + radius, y);
+
+            cairo_arc(PCAIRO, x + width - radius, y + radius, radius, -M_PI_2, 0);
+            cairo_arc(PCAIRO, x + width - radius, y + height - radius, radius, 0, M_PI_2);
+            cairo_arc(PCAIRO, x + radius, y + height - radius, radius, M_PI_2, M_PI);
+            cairo_arc(PCAIRO, x + radius, y + radius, radius, M_PI, -M_PI_2);
+
+            cairo_close_path(PCAIRO);
             cairo_fill(PCAIRO);
 
             cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
             cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-            cairo_set_font_size(PCAIRO, 18);
+            cairo_set_font_size(PCAIRO, 20);
             cairo_move_to(PCAIRO, CLICKPOS.x, CLICKPOS.y + 40);
             cairo_show_text(PCAIRO, hexBuffer);
 

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -427,18 +427,27 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
 
             const auto currentColor = getColorFromPixel(pSurface, CLICKPOS);
             char       hexBuffer[8];
-            sprintf(hexBuffer, "#%02x%02x%02x", currentColor.r, currentColor.g, currentColor.b);
+            sprintf(hexBuffer, "#%02X%02X%02X", currentColor.r, currentColor.g, currentColor.b);
 
             cairo_set_source_rgba(PCAIRO, 0.0, 0.0, 0.0, 0.5);
 
-            double x      = CLICKPOS.x;
-            double y      = CLICKPOS.y + 19;
-            double width  = 89;
-            double height = 30;
-            double radius = 6;
+            double x, y, width = 85, height = 28, radius = 6;
+
+            if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                x = CLICKPOS.x - 80;
+                y = CLICKPOS.y - 40;
+            } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
+                x = CLICKPOS.x;
+                y = CLICKPOS.y - 40;
+            } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                x = CLICKPOS.x - 80;
+                y = CLICKPOS.y + 20;
+            } else {
+                x = CLICKPOS.x;
+                y = CLICKPOS.y + 20;
+            }
 
             cairo_move_to(PCAIRO, x + radius, y);
-
             cairo_arc(PCAIRO, x + width - radius, y + radius, radius, -M_PI_2, 0);
             cairo_arc(PCAIRO, x + width - radius, y + height - radius, radius, 0, M_PI_2);
             cairo_arc(PCAIRO, x + radius, y + height - radius, radius, M_PI_2, M_PI);
@@ -449,8 +458,21 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
 
             cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
             cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-            cairo_set_font_size(PCAIRO, 20);
-            cairo_move_to(PCAIRO, CLICKPOS.x, CLICKPOS.y + 40);
+            cairo_set_font_size(PCAIRO, 18);
+
+            double padding = 5.0;
+            double textX   = x + padding;
+
+            if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
+            } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
+                cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
+            } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
+            } else {
+                cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
+            }
+
             cairo_show_text(PCAIRO, hexBuffer);
 
             cairo_surface_flush(PBUFFER->surface);

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -424,57 +424,58 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             cairo_arc(PCAIRO, CLICKPOS.x, CLICKPOS.y, 100 / SCALEBUFS.x, 0, 2 * M_PI);
             cairo_clip(PCAIRO);
             cairo_paint(PCAIRO);
+            if (!m_bDisableLive) {
+                const auto  currentColor = getColorFromPixel(pSurface, CLICKPOS);
+                std::string hexBuffer    = std::format("#{:02X}{:02X}{:02X}", currentColor.r, currentColor.g, currentColor.b);
 
-            const auto  currentColor = getColorFromPixel(pSurface, CLICKPOS);
-            std::string hexBuffer    = std::format("#{:02X}{:02X}{:02X}", currentColor.r, currentColor.g, currentColor.b);
+                cairo_set_source_rgba(PCAIRO, 0.0, 0.0, 0.0, 0.5);
 
-            cairo_set_source_rgba(PCAIRO, 0.0, 0.0, 0.0, 0.5);
+                double x, y, width = 85, height = 28, radius = 6;
 
-            double x, y, width = 85, height = 28, radius = 6;
+                if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                    x = CLICKPOS.x - 80;
+                    y = CLICKPOS.y - 40;
+                } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
+                    x = CLICKPOS.x;
+                    y = CLICKPOS.y - 40;
+                } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                    x = CLICKPOS.x - 80;
+                    y = CLICKPOS.y + 20;
+                } else {
+                    x = CLICKPOS.x;
+                    y = CLICKPOS.y + 20;
+                }
 
-            if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
-                x = CLICKPOS.x - 80;
-                y = CLICKPOS.y - 40;
-            } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
-                x = CLICKPOS.x;
-                y = CLICKPOS.y - 40;
-            } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
-                x = CLICKPOS.x - 80;
-                y = CLICKPOS.y + 20;
-            } else {
-                x = CLICKPOS.x;
-                y = CLICKPOS.y + 20;
+                cairo_move_to(PCAIRO, x + radius, y);
+                cairo_arc(PCAIRO, x + width - radius, y + radius, radius, -M_PI_2, 0);
+                cairo_arc(PCAIRO, x + width - radius, y + height - radius, radius, 0, M_PI_2);
+                cairo_arc(PCAIRO, x + radius, y + height - radius, radius, M_PI_2, M_PI);
+                cairo_arc(PCAIRO, x + radius, y + radius, radius, M_PI, -M_PI_2);
+
+                cairo_close_path(PCAIRO);
+                cairo_fill(PCAIRO);
+
+                cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
+                cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+                cairo_set_font_size(PCAIRO, 18);
+
+                double padding = 5.0;
+                double textX   = x + padding;
+
+                if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                    cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
+                } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
+                    cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
+                } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
+                    cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
+                } else {
+                    cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
+                }
+
+                cairo_show_text(PCAIRO, hexBuffer.c_str());
+
+                cairo_surface_flush(PBUFFER->surface);
             }
-
-            cairo_move_to(PCAIRO, x + radius, y);
-            cairo_arc(PCAIRO, x + width - radius, y + radius, radius, -M_PI_2, 0);
-            cairo_arc(PCAIRO, x + width - radius, y + height - radius, radius, 0, M_PI_2);
-            cairo_arc(PCAIRO, x + radius, y + height - radius, radius, M_PI_2, M_PI);
-            cairo_arc(PCAIRO, x + radius, y + radius, radius, M_PI, -M_PI_2);
-
-            cairo_close_path(PCAIRO);
-            cairo_fill(PCAIRO);
-
-            cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
-            cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-            cairo_set_font_size(PCAIRO, 18);
-
-            double padding = 5.0;
-            double textX   = x + padding;
-
-            if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50) && CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
-                cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
-            } else if (CLICKPOS.y > (PBUFFER->pixelSize.y - 50)) {
-                cairo_move_to(PCAIRO, textX, CLICKPOS.y - 20);
-            } else if (CLICKPOS.x > (PBUFFER->pixelSize.x - 100)) {
-                cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
-            } else {
-                cairo_move_to(PCAIRO, textX, CLICKPOS.y + 40);
-            }
-
-            cairo_show_text(PCAIRO, hexBuffer.c_str());
-
-            cairo_surface_flush(PBUFFER->surface);
             cairo_restore(PCAIRO);
             cairo_pattern_destroy(PATTERN);
         }

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -425,26 +425,18 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
             cairo_clip(PCAIRO);
             cairo_paint(PCAIRO);
 
-            const auto THECOLOR = getColorFromPixel(pSurface, CLICKPOS);
-            printf("thecolor has been gotten and it is %d %d %d\n", THECOLOR.r, THECOLOR.g, THECOLOR.b);
-
-            char hexBuffer[8];
-            sprintf(hexBuffer, "#%02x%02x%02x", THECOLOR.r, THECOLOR.g, THECOLOR.b);
+            const auto currentColor = getColorFromPixel(pSurface, CLICKPOS);
+            char       hexBuffer[8];
+            sprintf(hexBuffer, "#%02x%02x%02x", currentColor.r, currentColor.g, currentColor.b);
 
             cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
-            printf("hallo\n");
             cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
             cairo_set_font_size(PCAIRO, 18);
             cairo_move_to(PCAIRO, CLICKPOS.x, CLICKPOS.y + 40);
-            printf("pos is %f %f\n", CLICKPOS.x, CLICKPOS.y);
-            printf("Rendering hex code at position: (%f, %f)\n", CLICKPOS.x, CLICKPOS.y + 40);
-
-            printf("hexbuffer contains %s\n", hexBuffer);
             cairo_show_text(PCAIRO, hexBuffer);
+
             cairo_surface_flush(PBUFFER->surface);
-
             cairo_restore(PCAIRO);
-
             cairo_pattern_destroy(PATTERN);
         }
     } else if (!m_bRenderInactive) {

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -44,6 +44,7 @@ class CHyprpicker {
     bool                                        m_bRenderInactive = false;
     bool                                        m_bNoZoom         = false;
     bool                                        m_bNoFractional   = false;
+    bool                                        m_bDisableLive    = false;
 
     bool                                        m_bRunning = true;
 

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -40,11 +40,11 @@ class CHyprpicker {
 
     bool                                        m_bFancyOutput = true;
 
-    bool                                        m_bAutoCopy       = false;
-    bool                                        m_bRenderInactive = false;
-    bool                                        m_bNoZoom         = false;
-    bool                                        m_bNoFractional   = false;
-    bool                                        m_bDisableLive    = false;
+    bool                                        m_bAutoCopy          = false;
+    bool                                        m_bRenderInactive    = false;
+    bool                                        m_bNoZoom            = false;
+    bool                                        m_bNoFractional      = false;
+    bool                                        m_bDisableHexPreview = false;
 
     bool                                        m_bRunning = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,8 +33,8 @@ int main(int argc, char** argv, char** envp) {
                                                {"no-fractional", no_argument, NULL, 't'},
                                                {"quiet", no_argument, NULL, 'q'},
                                                {"verbose", no_argument, NULL, 'v'},
-                                               {"version", no_argument, NULL, 'V'},
                                                {"disable-hex-preview", no_argument, NULL, 'd'},
+                                               {"version", no_argument, NULL, 'V'},
                                                {NULL, 0, NULL, 0}};
 
         int                  c = getopt_long(argc, argv, ":f:hnarzqvtVd", long_options, &option_index);
@@ -66,7 +66,7 @@ int main(int argc, char** argv, char** envp) {
             case 't': g_pHyprpicker->m_bNoFractional = true; break;
             case 'q': Debug::quiet = true; break;
             case 'v': Debug::verbose = true; break;
-            case 'd': g_pHyprpicker->m_bDisableLive = true; break;
+            case 'd': g_pHyprpicker->m_bDisableHexPreview = true; break;
             case 'V': {
                 std::cout << "hyprpicker v" << HYPRPICKER_VERSION << "\n";
                 exit(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,8 @@ static void help(void) {
               << " -q | --quiet             | Disable most logs (leaves errors)\n"
               << " -v | --verbose           | Enable more logs\n"
               << " -t | --no-fractional     | Disable fractional scaling support\n"
-              << " -V | --version           | Print version info\n";
+              << " -V | --version           | Print version info\n"
+              << " -d | --disable-live      | Disable live preview of Hex code\n";
 }
 
 int main(int argc, char** argv, char** envp) {
@@ -23,19 +24,12 @@ int main(int argc, char** argv, char** envp) {
 
     while (true) {
         int                  option_index   = 0;
-        static struct option long_options[] = {{"autocopy", no_argument, NULL, 'a'},
-                                               {"format", required_argument, NULL, 'f'},
-                                               {"help", no_argument, NULL, 'h'},
-                                               {"no-fancy", no_argument, NULL, 'n'},
-                                               {"render-inactive", no_argument, NULL, 'r'},
-                                               {"no-zoom", no_argument, NULL, 'z'},
-                                               {"no-fractional", no_argument, NULL, 't'},
-                                               {"quiet", no_argument, NULL, 'q'},
-                                               {"verbose", no_argument, NULL, 'v'},
-                                               {"version", no_argument, NULL, 'V'},
-                                               {NULL, 0, NULL, 0}};
+        static struct option long_options[] = {{"autocopy", no_argument, NULL, 'a'},      {"format", required_argument, NULL, 'f'},    {"help", no_argument, NULL, 'h'},
+                                               {"no-fancy", no_argument, NULL, 'n'},      {"render-inactive", no_argument, NULL, 'r'}, {"no-zoom", no_argument, NULL, 'z'},
+                                               {"no-fractional", no_argument, NULL, 't'}, {"quiet", no_argument, NULL, 'q'},           {"verbose", no_argument, NULL, 'v'},
+                                               {"version", no_argument, NULL, 'V'},       {"disable-live", no_argument, NULL, 'd'},    {NULL, 0, NULL, 0}};
 
-        int                  c = getopt_long(argc, argv, ":f:hnarzqvtV", long_options, &option_index);
+        int                  c = getopt_long(argc, argv, ":f:hnarzqvtVd", long_options, &option_index);
         if (c == -1)
             break;
 
@@ -64,6 +58,7 @@ int main(int argc, char** argv, char** envp) {
             case 't': g_pHyprpicker->m_bNoFractional = true; break;
             case 'q': Debug::quiet = true; break;
             case 'v': Debug::verbose = true; break;
+            case 'd': g_pHyprpicker->m_bDisableLive = true; break;
             case 'V': {
                 std::cout << "hyprpicker v" << HYPRPICKER_VERSION << "\n";
                 exit(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv, char** envp) {
                                                {"version", no_argument, NULL, 'V'},
                                                {NULL, 0, NULL, 0}};
 
-        int                  c = getopt_long(argc, argv, ":f:hnarzqvtVd", long_options, &option_index);
+        int                  c = getopt_long(argc, argv, ":f:hnarzqvtdV", long_options, &option_index);
         if (c == -1)
             break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,17 +6,17 @@
 
 static void help(void) {
     std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n"
-              << " -a | --autocopy          | Automatically copies the output to the clipboard (requires wl-clipboard)\n"
-              << " -f | --format=fmt        | Specifies the output format (cmyk, hex, rgb, hsl, hsv)\n"
-              << " -n | --no-fancy          | Disables the \"fancy\" (aka. colored) outputting\n"
-              << " -h | --help              | Show this help message\n"
-              << " -r | --render-inactive   | Render (freeze) inactive displays\n"
-              << " -z | --no-zoom           | Disable the zoom lens\n"
-              << " -q | --quiet             | Disable most logs (leaves errors)\n"
-              << " -v | --verbose           | Enable more logs\n"
-              << " -t | --no-fractional     | Disable fractional scaling support\n"
-              << " -V | --version           | Print version info\n"
-              << " -d | --disable-live      | Disable live preview of Hex code\n";
+              << " -a | --autocopy            | Automatically copies the output to the clipboard (requires wl-clipboard)\n"
+              << " -f | --format=fmt          | Specifies the output format (cmyk, hex, rgb, hsl, hsv)\n"
+              << " -n | --no-fancy            | Disables the \"fancy\" (aka. colored) outputting\n"
+              << " -h | --help                | Show this help message\n"
+              << " -r | --render-inactive     | Render (freeze) inactive displays\n"
+              << " -z | --no-zoom             | Disable the zoom lens\n"
+              << " -q | --quiet               | Disable most logs (leaves errors)\n"
+              << " -v | --verbose             | Enable more logs\n"
+              << " -t | --no-fractional       | Disable fractional scaling support\n"
+              << " -d | --disable-hex-preview | Disable live preview of Hex code\n"
+              << " -V | --version             | Print version info\n";
 }
 
 int main(int argc, char** argv, char** envp) {
@@ -24,10 +24,18 @@ int main(int argc, char** argv, char** envp) {
 
     while (true) {
         int                  option_index   = 0;
-        static struct option long_options[] = {{"autocopy", no_argument, NULL, 'a'},      {"format", required_argument, NULL, 'f'},    {"help", no_argument, NULL, 'h'},
-                                               {"no-fancy", no_argument, NULL, 'n'},      {"render-inactive", no_argument, NULL, 'r'}, {"no-zoom", no_argument, NULL, 'z'},
-                                               {"no-fractional", no_argument, NULL, 't'}, {"quiet", no_argument, NULL, 'q'},           {"verbose", no_argument, NULL, 'v'},
-                                               {"version", no_argument, NULL, 'V'},       {"disable-live", no_argument, NULL, 'd'},    {NULL, 0, NULL, 0}};
+        static struct option long_options[] = {{"autocopy", no_argument, NULL, 'a'},
+                                               {"format", required_argument, NULL, 'f'},
+                                               {"help", no_argument, NULL, 'h'},
+                                               {"no-fancy", no_argument, NULL, 'n'},
+                                               {"render-inactive", no_argument, NULL, 'r'},
+                                               {"no-zoom", no_argument, NULL, 'z'},
+                                               {"no-fractional", no_argument, NULL, 't'},
+                                               {"quiet", no_argument, NULL, 'q'},
+                                               {"verbose", no_argument, NULL, 'v'},
+                                               {"version", no_argument, NULL, 'V'},
+                                               {"disable-hex-preview", no_argument, NULL, 'd'},
+                                               {NULL, 0, NULL, 0}};
 
         int                  c = getopt_long(argc, argv, ":f:hnarzqvtVd", long_options, &option_index);
         if (c == -1)


### PR DESCRIPTION
### Adds the feature to show the hex code under the picker while picking the colour. 

https://github.com/user-attachments/assets/a0c6f83e-fcf4-469e-a9a0-56288f8cd995

![hyprpicker with hexcode img1](https://github.com/user-attachments/assets/8158eeef-6b7a-422b-bbfe-b914e1af3704)

![hyprpicker with hexcode img2](https://github.com/user-attachments/assets/2f77de2b-49df-4495-acc1-fdafbaa78d1d)

