### PR TITLE
Fixed the issue with the negative HSV values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ string(STRIP ${VER_RAW} VERSION)
 
 project(
   hyprpicker
-  DESCRIPTION "A blazing fast wayland wallpaper utility"
+  DESCRIPTION "A wlroots-compatible Wayland color picker that does not suck"
   VERSION ${VERSION})
 
 set(CMAKE_MESSAGE_LOG_LEVEL "STATUS")

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -721,7 +721,7 @@ void CHyprpicker::initMouse() {
                     l_or_v = std::round(v * 100);
                 }
 
-                h = std::round(h<0?h+360:h);
+                h = std::round(h < 0 ? h + 360 : h);
                 s = std::round(s * 100);
 
                 if (m_bFancyOutput)

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -721,7 +721,7 @@ void CHyprpicker::initMouse() {
                     l_or_v = std::round(v * 100);
                 }
 
-                h = std::round(h);
+                h = std::round(h<0?h+360:h);
                 s = std::round(s * 100);
 
                 if (m_bFancyOutput)


### PR DESCRIPTION
When converting to HSV the hue will sometimes be negative for example:
![image](https://github.com/user-attachments/assets/3340d445-365c-44c9-ad06-04150460edb6)
Also see issue: https://github.com/hyprwm/hyprpicker/issues/100
The issue was that when the value is negative 360 needs to be added to it to make it positive because that is how HSV works apparently, here is a screenshot of it working:
![image](https://github.com/user-attachments/assets/91ec6b8b-9d76-4c9d-9a78-f0b574aca988)
Here are some websites I tested it against to make sure that correct HSV values are generated with the new modification:
https://www.rapidtables.com/convert/color/rgb-to-hsv.html
https://colordesigner.io/convert/rgbtohsv
https://www.calculatorology.com/rgb-to-hsv-conversion/
In addition here is some guy with 168 upvotes and a accepted answer on stackoverflow adding 360 to h value if it is less than 0 when converting rgb to hsv:
![image](https://github.com/user-attachments/assets/21d4191c-3cfa-422d-8ebc-d41cb398a0be)
https://stackoverflow.com/questions/3018313/algorithm-to-convert-rgb-to-hsv-and-hsv-to-rgb-in-range-0-255-for-both
Also while doing this I noticed that the description in the CMakeLists.txt is for hyprpaper and I updated it to match the description for this project.