### PR TITLE
clang-tidy: fix some errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,12 @@
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*\.hpp'
-FormatStyle: file
+FormatStyle: 'file'
 Checks: >
   -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-forward-declararion-namespace,
-  -bugprone-forward-declararion-namespace,
+  -bugprone-forward-declaration-namespace,
+  -bugprone-forward-declaration-namespace,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-branch-clone,


### PR DESCRIPTION
Y'know, i'll fix every clang-tidy, that was c+p from Hyprland(that's my fault for not checking clang-tidy errors and docs), but i'll not fix Hyprland one, bc fix already in hyprwm/Hyprland#9543 and that's not fault of mine
Anyway, same as hyprwm/hyprlock#751