### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Launch it. Click. That's it.
 
 See `hyprpicker --help`.
 
-# Building
+# Installation
 
 ## Arch
 
-`yay -S hyprpicker-git`
+`sudo pacman -S hyprpicker`
 
-## Manual
+## Manual (Building)
 
 Install dependencies:
  - cmake


### PR DESCRIPTION
hyperpicker is now in extra packages of [archlinux official repo](https://archlinux.org/packages/extra/x86_64/hyprpicker/)