### PR TITLE
Add null check for cursor shape device

### DIFF
--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -630,7 +630,8 @@ void CHyprpicker::initMouse() {
             }
         }
 
-        m_pCursorShapeDevice->sendSetShape(serial, WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR);
+        if (m_pCursorShapeDevice)
+            m_pCursorShapeDevice->sendSetShape(serial, WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR);
 
         markDirty();
     });


### PR DESCRIPTION
Fixes segmentation fault when running on Wayland compositors that don't support the cursor_shape_v1 protocol (e.g., Wayfire).

The crash occurs in the pointer enter event handler when attempting to call m_pCursorShapeDevice->sendSetShape() without checking if the device was successfully initialized. On compositors without cursor_shape_v1 support, m_pCursorShapeDevice remains null, leading to a null pointer dereference.

Added a null check before calling sendSetShape(), allowing hyprpicker to work on compositors that don't support cursor_shape_v1.

Tested on Wayfire 0.10.0 with wlroots 0.19.1, which does not support cursor_shape_v1. Before the fix, hyprpicker crashed with a segmentation fault. After the fix, hyprpicker runs with only the expected warning message.