### PR TITLE
add missing include <charconv> to main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <format>
 #include <regex>
+#include <charconv>
 #include <strings.h>
 
 #include <iostream>


### PR DESCRIPTION
This pr adds the missing #include <charconv> in main.cpp

Which fixes compilation on musl libc, otherwise it fails with the message:

```
error: no member named 'from_chars' in namespace 'std'
```