### PR TITLE
fix: clean up files on SIGTERM

### DIFF
--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -13,7 +13,7 @@
 #include <xkbcommon/xkbcommon.h>
 
 static void sigHandler(int sig) {
-    g_pHyprpicker->m_vLayerSurfaces.clear();
+    g_pHyprpicker->m_vLayerSurfaces.clear(); // Cleans up the /run files
     exit(0);
 }
 
@@ -297,8 +297,8 @@ void CHyprpicker::markDirty() {
     }
 }
 
-SP<SPoolBuffer> CHyprpicker::getBufferForLS(CLayerSurface* pLS) {
-    SP<SPoolBuffer> returns = nullptr;
+WP<SPoolBuffer> CHyprpicker::getBufferForLS(CLayerSurface* pLS) {
+    WP<SPoolBuffer> returns;
 
     for (auto i = 0; i < 2; ++i) {
         if (!pLS->buffers[i] || pLS->buffers[i]->busy)
@@ -353,7 +353,7 @@ int CHyprpicker::createPoolFile(size_t size, std::string& name) {
     return FD;
 }
 
-void CHyprpicker::convertBuffer(SP<SPoolBuffer> pBuffer) {
+void CHyprpicker::convertBuffer(WP<SPoolBuffer> pBuffer) {
     switch (pBuffer->format) {
         case WL_SHM_FORMAT_ARGB8888:
         case WL_SHM_FORMAT_XRGB8888: break;
@@ -404,7 +404,7 @@ void CHyprpicker::convertBuffer(SP<SPoolBuffer> pBuffer) {
 }
 
 // Mallocs a new buffer, which needs to be free'd!
-void* CHyprpicker::convert24To32Buffer(SP<SPoolBuffer> pBuffer) {
+void* CHyprpicker::convert24To32Buffer(WP<SPoolBuffer> pBuffer) {
     uint8_t* newBuffer       = (uint8_t*)malloc((size_t)pBuffer->pixelSize.x * pBuffer->pixelSize.y * 4);
     int      newBufferStride = pBuffer->pixelSize.x * 4;
     uint8_t* oldBuffer       = (uint8_t*)pBuffer->data;

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -292,8 +292,8 @@ void CHyprpicker::markDirty() {
     }
 }
 
-WP<SPoolBuffer> CHyprpicker::getBufferForLS(CLayerSurface* pLS) {
-    WP<SPoolBuffer> returns;
+SP<SPoolBuffer> CHyprpicker::getBufferForLS(CLayerSurface* pLS) {
+    SP<SPoolBuffer> returns = nullptr;
 
     for (auto i = 0; i < 2; ++i) {
         if (!pLS->buffers[i] || pLS->buffers[i]->busy)
@@ -348,7 +348,7 @@ int CHyprpicker::createPoolFile(size_t size, std::string& name) {
     return FD;
 }
 
-void CHyprpicker::convertBuffer(WP<SPoolBuffer> pBuffer) {
+void CHyprpicker::convertBuffer(SP<SPoolBuffer> pBuffer) {
     switch (pBuffer->format) {
         case WL_SHM_FORMAT_ARGB8888:
         case WL_SHM_FORMAT_XRGB8888: break;
@@ -399,7 +399,7 @@ void CHyprpicker::convertBuffer(WP<SPoolBuffer> pBuffer) {
 }
 
 // Mallocs a new buffer, which needs to be free'd!
-void* CHyprpicker::convert24To32Buffer(WP<SPoolBuffer> pBuffer) {
+void* CHyprpicker::convert24To32Buffer(SP<SPoolBuffer> pBuffer) {
     uint8_t* newBuffer       = (uint8_t*)malloc((size_t)pBuffer->pixelSize.x * pBuffer->pixelSize.y * 4);
     int      newBufferStride = pBuffer->pixelSize.x * 4;
     uint8_t* oldBuffer       = (uint8_t*)pBuffer->data;

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -13,8 +13,7 @@
 #include <xkbcommon/xkbcommon.h>
 
 static void sigHandler(int sig) {
-    g_pHyprpicker->m_vLayerSurfaces.clear(); // Cleans up the /run files
-    exit(0);
+    g_pHyprpicker->m_bRunning.store(false);
 }
 
 void CHyprpicker::init() {
@@ -123,11 +122,7 @@ void CHyprpicker::init() {
     while (m_bRunning && wl_display_dispatch(m_pWLDisplay) != -1) {
         //renderSurface(m_pLastSurface);
     }
-
-    if (m_pWLDisplay) {
-        wl_display_disconnect(m_pWLDisplay);
-        m_pWLDisplay = nullptr;
-    }
+    finish(1);
 }
 
 void CHyprpicker::finish(int code) {

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -73,10 +73,10 @@ class CHyprpicker {
     void                                        initKeyboard();
     void                                        initMouse();
 
-    SP<SPoolBuffer>                             getBufferForLS(CLayerSurface*);
+    WP<SPoolBuffer>                             getBufferForLS(CLayerSurface*);
 
-    void                                        convertBuffer(SP<SPoolBuffer>);
-    void*                                       convert24To32Buffer(SP<SPoolBuffer>);
+    void                                        convertBuffer(WP<SPoolBuffer>);
+    void*                                       convert24To32Buffer(WP<SPoolBuffer>);
 
     void                                        markDirty();
 

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -53,7 +53,7 @@ class CHyprpicker {
     bool                                        m_bDisablePreview = false;
     bool                                        m_bUseLowerCase   = false;
 
-    bool                                        m_bRunning      = true;
+    volatile std::atomic<bool>                  m_bRunning      = true;
     float                                       m_fZoomScale    = 10.0;
     int                                         m_iCircleRadius = 100;
 

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -73,10 +73,10 @@ class CHyprpicker {
     void                                        initKeyboard();
     void                                        initMouse();
 
-    WP<SPoolBuffer>                             getBufferForLS(CLayerSurface*);
+    SP<SPoolBuffer>                             getBufferForLS(CLayerSurface*);
 
-    void                                        convertBuffer(WP<SPoolBuffer>);
-    void*                                       convert24To32Buffer(WP<SPoolBuffer>);
+    void                                        convertBuffer(SP<SPoolBuffer>);
+    void*                                       convert24To32Buffer(SP<SPoolBuffer>);
 
     void                                        markDirty();
 


### PR DESCRIPTION
This hopefully fixes #152 . I couldn't get the screenshot script to work on my system though, so I just tested with a simple one that kills hyprpicker repeatedly.

## Changes

I changed the all of the references to SPoolBuffer to be weak pointers except the one from CLayerSurface. This means that when a SIGTERM is received and the sigHandler calls g_pHyprpicker->m_vLayerSurfaces.clear() it will actually call the destructor for all the SPoolBuffers(which removes the /run files) because all other references to them are weak pointers instead of shared pointers.

## Testing

Tested this with a command that kills hyprpicker repeatedly:
```bash
for i in $(seq 1 20); do hyprpicker& sleep 0.1; kill -TERM $(pidof hyprpicker); done
```

Before the changes there was a chance for hyprpicker to randomly miss the cleanup of some /run files when the command was ran. After the changes hyprpicker successfully cleans up the /run files.