### PR TITLE
Input: include cursor in frozen preview

### DIFF
--- a/doc/hyprpicker.1
+++ b/doc/hyprpicker.1
@@ -6,7 +6,7 @@
 .Nd wlroots-compatible wayland color picker
 .Sh SYNOPSIS
 .Nm
-.Op Fl anh
+.Op Fl acnh
 .Op Fl f Ar fmt
 .Sh DESCRIPTION
 The
@@ -56,6 +56,8 @@ Disable colored output.
 Default behavior is to color the output in the same color as the selected pixel.
 .It Fl h , Fl Fl help
 Display a help message and exit successfully from the program.
+.It Fl c , Fl Fl cursor
+Include the cursor in the frozen preview.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width NO_COLOR

--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -113,7 +113,7 @@ void CHyprpicker::init() {
 
         m_pLastSurface = m_vLayerSurfaces.back().get();
 
-        m->pSCFrame = makeShared<CCZwlrScreencopyFrameV1>(m_pScreencopyMgr->sendCaptureOutput(false, m->output->resource()));
+        m->pSCFrame = makeShared<CCZwlrScreencopyFrameV1>(m_pScreencopyMgr->sendCaptureOutput(m_bIncludeCursor, m->output->resource()));
         m->pLS      = m_vLayerSurfaces.back().get();
         m->initSCFrame();
     }

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -52,6 +52,7 @@ class CHyprpicker {
     bool                                        m_bNoFractional   = false;
     bool                                        m_bDisablePreview = false;
     bool                                        m_bUseLowerCase   = false;
+    bool                                        m_bIncludeCursor  = false;
 
     bool                                        m_bRunning      = true;
     float                                       m_fZoomScale    = 10.0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ static void help() {
               << " -v | --verbose             | Enable more logs\n"
               << " -t | --no-fractional       | Disable fractional scaling support\n"
               << " -d | --disable-preview     | Disable live preview of color\n"
+              << " -c | --cursor              | Include cursor in the frozen preview\n"
               << " -l | --lowercase-hex       | Outputs the hexcode in lowercase\n"
               << " -s | --scale=scale         | Set the zoom scale (between 1 and 10)\n"
               << " -u | --radius=radius       | Set the circle radius (between 1 and 1000)\n"
@@ -46,13 +47,14 @@ int main(int argc, char** argv, char** envp) {
                                                {"quiet", no_argument, nullptr, 'q'},
                                                {"verbose", no_argument, nullptr, 'v'},
                                                {"disable-preview", no_argument, nullptr, 'd'},
+                                               {"cursor", no_argument, nullptr, 'c'},
                                                {"lowercase-hex", no_argument, nullptr, 'l'},
                                                {"version", no_argument, nullptr, 'V'},
                                                {"scale", required_argument, nullptr, 's'},
                                                {"radius", required_argument, nullptr, 'u'},
                                                {nullptr, 0, nullptr, 0}};
 
-        int                  c = getopt_long(argc, argv, ":f:o:hnbarzqvtdlVs:u:", long_options, &option_index);
+        int                  c = getopt_long(argc, argv, ":f:o:hnbarzqvtdlcVs:u:", long_options, &option_index);
         if (c == -1)
             break;
 
@@ -84,6 +86,7 @@ int main(int argc, char** argv, char** envp) {
             case 'q': Debug::quiet = true; break;
             case 'v': Debug::verbose = true; break;
             case 'd': g_pHyprpicker->m_bDisablePreview = true; break;
+            case 'c': g_pHyprpicker->m_bIncludeCursor = true; break;
             case 'l': g_pHyprpicker->m_bUseLowerCase = true; break;
             case 'V': {
                 std::cout << "hyprpicker v" << HYPRPICKER_VERSION << "\n";


### PR DESCRIPTION
## Description

Hi!

This PR adds `-c, --cursor` to include the cursor in hyprpicker's frozen screencopy.

This will help with grimblast's frozen area selection, where hyprpicker provides the frozen layer and grim captures that layer without capturing the second select cursor if we are using hardware cursors (it's still borked with software cursors unfortunately).

So for grimblast, that means we can do `--freeze --cursor area` together!

## Related

Part of #65.
Needed for hyprwm/contrib#92.

## Testing

```sh
cmake --build build --target hyprpicker
```

Also checked:

```
hyprpicker --help
hyprpicker -rzc
```
