### PR TITLE
fix: updated notification app name

### DIFF
--- a/src/notify/Notify.cpp
+++ b/src/notify/Notify.cpp
@@ -13,7 +13,7 @@
 void NNotify::send(std::string hexColor, std::string formattedColor) {
     std::string             notifyBody = std::format("<span>Selected color: <span color='{}'><b>{}</b></span></span>", hexColor, formattedColor);
 
-    Hyprutils::OS::CProcess notify("notify-send", {"-t", "5000", "-i", "color-select-symbolic", "Color Picker", notifyBody});
+    Hyprutils::OS::CProcess notify("notify-send", {"-a", "hyprpicker", "-t", "5000", "-i", "color-select-symbolic", "Color Picker", notifyBody});
 
     notify.runAsync();
 }


### PR DESCRIPTION
Sets the app name of the notification sent to "hyprpicker".

Old behavior:
<img width="691" height="196" alt="image" src="https://github.com/user-attachments/assets/62cfc470-1e0a-4e35-87d9-233aa173e014" />


Updated behavior:
<img width="678" height="144" alt="image" src="https://github.com/user-attachments/assets/7922042b-7a1d-491e-83c1-a16490bacbd3" />
