### PR TITLE
Add libc++ < 20 fallback for floating-point scale value validation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,12 +94,24 @@ int main(int argc, char** argv, char** envp) {
             }
             case 's': {
                 float value;
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 200000
+                try {
+                    size_t pos;
+                    value = std::stof(optarg, &pos);
+                    if (pos != strlen(optarg))
+                        throw std::invalid_argument("");
+                } catch (...) {
+                    std::cerr << "Invalid scale value: " << optarg << "\n";
+                    exit(1);
+                }
+#else
                 auto  result = std::from_chars(optarg, optarg + strlen(optarg), value);
 
                 if (result.ec != std::errc() || result.ptr != optarg + strlen(optarg)) {
                     std::cerr << "Invalid scale value: " << optarg << "\n";
                     exit(1);
                 }
+#endif
 
                 if (value < 1.0f || value > 10.0f) {
                     std::cerr << "Scale must be between 1 and 10!\n";


### PR DESCRIPTION
libc++ prior to version 20 does not implement `std::from_chars` for floating point types, which causes builds to fail on systems using older libc++ versions (e.g. FreeBSD 14/15).

Add a small fallback using `std::stof` for building with libc++ < 20.

While libstdc++, or libc++ 20 or later continue to use the existing `std::from_chars` implementation, this change restores compatibility with older libc++ versions.