### PR TITLE
feat: Added cli-option to set both font-family and font-weight.

### DIFF
--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <format>
+#include <iostream>
 #include <mutex>
 #include <hyprutils/math/Vector2D.hpp>
 #include <wayland-client-protocol.h>
@@ -611,7 +612,7 @@ void CHyprpicker::renderSurface(CLayerSurface* pSurface, bool forceInactive) {
                 cairo_fill(PCAIRO);
 
                 cairo_set_source_rgba(PCAIRO, 1.0, 1.0, 1.0, 1.0);
-                cairo_select_font_face(PCAIRO, "monospace", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+                cairo_select_font_face(PCAIRO, m_sFont, CAIRO_FONT_SLANT_NORMAL, m_cWeight);
                 cairo_set_font_size(PCAIRO, 18);
 
                 double padding = 5.0;

--- a/src/hyprpicker.hpp
+++ b/src/hyprpicker.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cairo.h>
 #include <mutex>
 #include "defines.hpp"
 #include "helpers/LayerSurface.hpp"
@@ -42,6 +43,9 @@ class CHyprpicker {
 
     eOutputMode                                 m_bSelectedOutputMode = OUTPUT_HEX;
     std::string                                 m_sOutputFormat       = "";
+
+    const char*                                 m_sFont   = "monospace";
+    cairo_font_weight_t                         m_cWeight = CAIRO_FONT_WEIGHT_NORMAL;
 
     bool                                        m_bFancyOutput = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,33 +1,43 @@
+#include <cairo.h>
+#include <cstdio>
+#include <bits/getopt_core.h>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <format>
-#include <regex>
 #include <charconv>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 #include <strings.h>
 
 #include <iostream>
+#include <vector>
 
 #include "hyprpicker.hpp"
 #include "src/debug/Log.hpp"
 
 static void help() {
     std::cout << "Hyprpicker usage: hyprpicker [arg [...]].\n\nArguments:\n"
-              << " -a | --autocopy            | Automatically copies the output to the clipboard (requires wl-clipboard)\n"
-              << " -f | --format=fmt          | Specifies the output format (cmyk, hex, rgb, hsl, hsv)\n"
-              << " -o | --output-format=fmt   | Specifies how the output color should be formatted e.g. rgb({0}, {1}, {2}) would output rgb(red, green, blue) if --format=rgb\n"
-              << " -n | --notify              | Sends a desktop notification when a color is picked (requires notify-send and a notification daemon like dunst)\n"
-              << " -b | --no-fancy            | Disables the \"fancy\" (aka. colored) outputting\n"
-              << " -h | --help                | Show this help message\n"
-              << " -r | --render-inactive     | Render (freeze) inactive displays\n"
-              << " -z | --no-zoom             | Disable the zoom lens\n"
-              << " -q | --quiet               | Disable most logs (leaves errors)\n"
-              << " -v | --verbose             | Enable more logs\n"
-              << " -t | --no-fractional       | Disable fractional scaling support\n"
-              << " -d | --disable-preview     | Disable live preview of color\n"
-              << " -c | --cursor              | Include cursor in the frozen preview\n"
-              << " -l | --lowercase-hex       | Outputs the hexcode in lowercase\n"
-              << " -s | --scale=scale         | Set the zoom scale (between 1 and 10)\n"
-              << " -u | --radius=radius       | Set the circle radius (between 1 and 1000)\n"
-              << " -V | --version             | Print version info\n";
+              << " -a | --autocopy                   | Automatically copies the output to the clipboard (requires wl-clipboard)\n"
+              << " -f | --format=fmt                 | Specifies the output format (cmyk, hex, rgb, hsl, hsv)\n"
+              << " -o | --output-format=fmt          | Specifies how the output color should be formatted e.g. rgb({0}, {1}, {2}) would output rgb(red, green, blue) if "
+                 "--format=rgb\n"
+              << " -n | --notify                     | Sends a desktop notification when a color is picked (requires notify-send and a notification daemon like dunst)\n"
+              << " -b | --no-fancy                   | Disables the \"fancy\" (aka. colored) outputting\n"
+              << " -h | --help                       | Show this help message\n"
+              << " -r | --render-inactive            | Render (freeze) inactive displays\n"
+              << " -z | --no-zoom                    | Disable the zoom lens\n"
+              << " -q | --quiet                      | Disable most logs (leaves errors)\n"
+              << " -v | --verbose                    | Enable more logs\n"
+              << " -t | --no-fractional              | Disable fractional scaling support\n"
+              << " -d | --disable-preview            | Disable live preview of color\n"
+              << " -c | --cursor                     | Include cursor in the frozen preview\n"
+              << " -l | --lowercase-hex              | Outputs the hexcode in lowercase\n"
+              << " -s | --scale=scale                | Set the zoom scale (between 1 and 10)\n"
+              << " -u | --radius=radius              | Set the circle radius (between 1 and 1000)\n"
+              << " -V | --version                    | Print version info\n"
+              << " -F | --font=font,{bold|normal}    | Set the font to use\n";
 }
 
 int main(int argc, char** argv, char** envp) {
@@ -52,9 +62,10 @@ int main(int argc, char** argv, char** envp) {
                                                {"version", no_argument, nullptr, 'V'},
                                                {"scale", required_argument, nullptr, 's'},
                                                {"radius", required_argument, nullptr, 'u'},
+                                               {"font", required_argument, nullptr, 'F'},
                                                {nullptr, 0, nullptr, 0}};
 
-        int                  c = getopt_long(argc, argv, ":f:o:hnbarzqvtdlcVs:u:", long_options, &option_index);
+        int                  c = getopt_long(argc, argv, ":f:o:hnbarzqvtdlcVs:u:F:", long_options, &option_index);
         if (c == -1)
             break;
 
@@ -105,7 +116,7 @@ int main(int argc, char** argv, char** envp) {
                     exit(1);
                 }
 #else
-                auto  result = std::from_chars(optarg, optarg + strlen(optarg), value);
+                auto result = std::from_chars(optarg, optarg + strlen(optarg), value);
 
                 if (result.ec != std::errc() || result.ptr != optarg + strlen(optarg)) {
                     std::cerr << "Invalid scale value: " << optarg << "\n";
@@ -137,6 +148,35 @@ int main(int argc, char** argv, char** envp) {
                 }
 
                 g_pHyprpicker->m_iCircleRadius = value;
+                break;
+            }
+            case 'F': {
+                std::vector<std::string> tokens;
+                std::istringstream       stream(optarg);
+                std::string              token;
+
+                while (std::getline(stream, token, ',')) {
+                    tokens.push_back(token);
+                }
+
+                if (tokens.size() > 2) {
+                    std::cerr << "Invalid font-value!\n";
+                    exit(1);
+                }
+
+                g_pHyprpicker->m_sFont = strdup(tokens[0].c_str());
+
+                if (tokens.size() == 2) {
+                    const std::string& weight = tokens[1];
+                    if (weight == "bold") {
+                        g_pHyprpicker->m_cWeight = CAIRO_FONT_WEIGHT_BOLD;
+                    } else if (weight == "normal") {
+                        g_pHyprpicker->m_cWeight = CAIRO_FONT_WEIGHT_NORMAL;
+                    } else {
+                        std::cerr << "Invalid weight-value!\n";
+                        exit(1);
+                    }
+                }
                 break;
             }
             default: help(); exit(1);


### PR DESCRIPTION
I really like hyprpicker, but the only thing that kinda put me off was that it always used the default monospace font.

I know that its just a tool and this is just a really minor detail, but I thought why not add it. Therefore I added a simple option `-F`, through which you can set both font-family and font-weight.