### PR TITLE
fix: make auto-clipboard respect output format in HEX mode

### DIFF
--- a/src/hyprpicker.cpp
+++ b/src/hyprpicker.cpp
@@ -208,10 +208,10 @@ void CHyprpicker::outputColor() {
                 Debug::log(NONE, formattedColor.c_str());
 
             if (m_bAutoCopy)
-                NClipboard::copy(hexColor);
+                NClipboard::copy(formattedColor);
 
             if (m_bNotify)
-                NNotify::send(hexColor, hexColor);
+                NNotify::send(hexColor, formattedColor);
 
             finish();
             break;


### PR DESCRIPTION
Previously -a (auto-copy) always copied hardcoded #rrggbb to clipboard in HEX mode, ignoring the -o (output format) flag. Now uses the formatted color string, consistent with CMYK/RGB/HSL/HSV modes.

Also fixes notification body to use formatted color instead of raw hex.