### PR TITLE
Fix hyprpicker not attaching a buffer to Jay

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -110,6 +110,8 @@ void SMonitor::initSCFrame() {
 
         pLS->screenBuffer = newBuf;
 
+        g_pHyprpicker->recheckACK();
+        
         g_pHyprpicker->renderSurface(pLS);
 
         pSCFrame.reset();


### PR DESCRIPTION
Call recheckACK() one more time so hyprpicker can attach a buffer to Jay compositor properly.

I'm not much of a programmer but I found that this one line patch fixes the issue with hyprpicker not launching on Jay, and hopefully doesn't break anything.

fixes issue #144 